### PR TITLE
Updated Example Config

### DIFF
--- a/config/config_example.php
+++ b/config/config_example.php
@@ -35,7 +35,7 @@
     $warn_pwned_password        = true;
     
     // WebSocket connection
-    $ws_target                  = "localhost/";
+    $ws_target                  = "localhost";
     $ws_port                    = 6001;
     $ws_use_ssl                 = false;
 

--- a/config/config_example.php
+++ b/config/config_example.php
@@ -25,6 +25,7 @@
     $dbpass                     = "segs123";
     $accdb                      = "segs";
     $chardb                     = "segs_game";
+    $dbport                     = 3306;
 
     // User Account Settings;
     $min_username_len           = 6;
@@ -34,7 +35,7 @@
     $warn_pwned_password        = true;
     
     // WebSocket connection
-    $ws_target                  = "ws://localhost/";
+    $ws_target                  = "localhost/";
     $ws_port                    = 6001;
     $ws_use_ssl                 = false;
 


### PR DESCRIPTION
Out of the box, the example config introduced a couple minor issues:

1. The example for the websocket address included 'ws://', which is added in dashboard.php, so the connection string looked like "ws://ws://loclahost:6001". Removed the "ws:// from the $ws_target variable in config.php. 
2. Added the $dbport variable to config.php as the getAccount.php script was calling for it, but it wasn't defined in the config. 

These changes should allow users to deploy this a little smoother, after using the composer script for installing prerequisite parts of the WebUI. 